### PR TITLE
Removes the pulp-operator subscription.

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -97,28 +97,6 @@ objects:
       # For now, it is useful to have the container running. We can run commands on it.
       sleep 9999999999
 
-- apiVersion: operators.coreos.com/v1alpha1
-  kind: Subscription
-  metadata:
-    labels:
-      operators.coreos.com/pulp-operator.pulp: ""
-    name: pulp-operator
-  # namespace: "${ENV_NAME}"
-  spec:
-    channel: beta
-    installPlanApproval: Automatic
-    name: pulp-operator
-    source: community-operators
-    sourceNamespace: openshift-marketplace
-    startingCSV: pulp-operator.v1.0.0-beta.2
-    config:
-      resources:
-        requests:
-          memory: "64Mi"
-          cpu: "250m"
-        limits:
-          memory: "128Mi"
-          cpu: "500m"
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:


### PR DESCRIPTION
If Pulp services will be needed for Image Builder in the future, we will deploy them using clowder.